### PR TITLE
Allow configuring the start of DCHP range

### DIFF
--- a/libvirt/resource_libvirt_network.go
+++ b/libvirt/resource_libvirt_network.go
@@ -220,6 +220,22 @@ func resourceLibvirtNetwork() *schema.Resource {
 							Optional: true,
 							Required: false,
 						},
+						"range_start_offset": {
+							Type:     schema.TypeInt,
+							Default:  0,
+							Optional: true,
+							Required: false,
+							ValidateFunc: func(v interface{}, k string) ([]string, []error) {
+								i := v.(int)
+								if i < 2 || i > 65535 {
+									return nil, []error{
+										fmt.Errorf("%s: must be between 2 and 65535, inclusive, got %v", k, v),
+									}
+								} else {
+									return nil, nil
+								}
+							},
+						},
 					},
 				},
 			},

--- a/libvirt/resource_libvirt_network_test.go
+++ b/libvirt/resource_libvirt_network_test.go
@@ -412,11 +412,31 @@ func TestAccLibvirtNetwork_DhcpEnabled(t *testing.T) {
 					addresses = ["10.17.3.0/24"]
 					dhcp {
 						enabled = true
+						range_start_offset = 16
 					}
 				}`, randomNetworkResource, randomNetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("libvirt_network."+randomNetworkResource, "dhcp.0.enabled", "true"),
-					testAccCheckLibvirtNetworkDhcpStatus("libvirt_network."+randomNetworkResource, "enabled"),
+					resource.TestCheckResourceAttr("libvirt_network."+randomNetworkResource, "dhcp.0.range_start_offset", "16"),
+					testAccCheckLibvirtNetworkDhcpStatus("libvirt_network."+randomNetworkResource, "enabled", []DHCPRange{{"10.17.3.16", "10.17.3.254"}}),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+				resource "libvirt_network" "%s" {
+					name      = "%s"
+					mode      = "nat"
+					domain    = "k8s.local"
+					addresses = ["2001:db8:ca2:2::/64"]
+					dhcp {
+						enabled = true
+						range_start_offset = 65530
+					}
+				}`, randomNetworkResource, randomNetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("libvirt_network."+randomNetworkResource, "dhcp.0.enabled", "true"),
+					resource.TestCheckResourceAttr("libvirt_network."+randomNetworkResource, "dhcp.0.range_start_offset", "65530"),
+					testAccCheckLibvirtNetworkDhcpStatus("libvirt_network."+randomNetworkResource, "enabled", []DHCPRange{{"2001:db8:ca2:2::fffa", "2001:db8:ca2:2::fffe"}}),
 				),
 			},
 		},
@@ -446,7 +466,7 @@ func TestAccLibvirtNetwork_DhcpDisabled(t *testing.T) {
 				}`, randomNetworkResource, randomNetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("libvirt_network."+randomNetworkResource, "dhcp.0.enabled", "false"),
-					testAccCheckLibvirtNetworkDhcpStatus("libvirt_network."+randomNetworkResource, "disabled"),
+					testAccCheckLibvirtNetworkDhcpStatus("libvirt_network."+randomNetworkResource, "disabled", nil),
 				),
 			},
 		},

--- a/website/docs/r/network.markdown
+++ b/website/docs/r/network.markdown
@@ -187,18 +187,27 @@ resource "libvirt_network" "k8snet" {
 }
 ```
 
-* `dhcp` - (Optional) DHCP configuration. 
+* `dhcp` - (Optional) DHCP configuration.
    You need to use it in conjuction with the adresses variable.
   * `enabled` - (Optional) when false, disable the DHCP server
+  * `range_start_offset` - (Optional) a non-negative integer offset from the
+    start of subnet(s) defined by `addresses` to use as the DHCP range.
+    Defaults to `2` and cannot be less than `2` (first address is the network
+    address and the second is the gateway address) or greater than `65535`
+    (maximum number of addresses supported by libvirt in a subnet).
+
 ```hcl
-				resource "libvirt_network" "test_net" {
-					name      = "networktest"
-					mode      = "nat"
-					domain    = "k8s.local"
-					addresses = ["10.17.3.0/24"]
-					dhcp {
-						enabled = true
-					}
+  resource "libvirt_network" "test_net" {
+    name      = "networktest"
+    mode      = "nat"
+    domain    = "k8s.local"
+    addresses = ["10.17.3.0/24"]
+    dhcp {
+      enabled = true
+      # Omit the first /28 from the DHCP range, i.e. use
+      # 10.17.3.16 - 10.17.3.254
+      range_start_offset = 16
+    }
 ```
 
 * `dnsmasq_options` - (Optional) configuration of Dnsmasq options for the network


### PR DESCRIPTION
Currently, DHCP, if enabled, uses the entire range of network addresses,
sans network, gateway and broadcast.  This makes life difficult for
scenarios where some static address allocation is needed and is
performed outside of Terraform configuration.  Help this by allowing the
configuration of the DHCP address range via the new `range_start_offset`
attribute on the `dhcp` block.  The default is `2`, which is equivalent
to the current behavior of skipping the first two addresses.